### PR TITLE
Add support for custom templates for email

### DIFF
--- a/emonoda/plugins/confetti/__init__.py
+++ b/emonoda/plugins/confetti/__init__.py
@@ -31,9 +31,14 @@ from .. import BaseExtension
 
 
 # =====
-def templated(name, **kwargs):
-    data = pkgutil.get_data(__name__, os.path.join("templates", name))
-    template = textwrap.dedent(data.decode()).strip()
+def templated(name, template_filename, **kwargs):
+    if template_filename:
+        with open(os.path.expanduser(template_filename)) as template_file:
+            data = template_file.read()
+    else:
+        data = pkgutil.get_data(__name__, os.path.join("templates", name))
+        data = data.decode()
+    template = textwrap.dedent(data).strip()
     return mako.template.Template(template).render(**kwargs).strip()
 
 


### PR DESCRIPTION
Добавил возможность пользователям создавать собственные заготовки для сообщений на почту. Ключ конфига `confetti/email/template`, если указан, указывает на файл заготовки. Может содержать `{ctype}` и `{source}` теги форматирования для предоставления различных заготовок для разных ситуаций.