### PR TITLE
Совместимость с форком модуля python-transmissionrpc

### DIFF
--- a/emonoda/plugins/clients/transmission.py
+++ b/emonoda/plugins/clients/transmission.py
@@ -40,13 +40,21 @@ from . import build_files
 try:
     import transmissionrpc
 except ImportError:
-    transmissionrpc = None
+    try:
+        import transmission_rpc as transmissionrpc
+    except ImportError:
+        transmissionrpc = None
+    else:
+        transmissionrpc.project = "forked"
+else:
+    transmissionrpc.project = "original"
 
 
 # =====
 class Plugin(BaseClient):
     # API description:
     #   http://pythonhosted.org/transmissionrpc/
+    #   (or https://transmission-rpc.readthedocs.io for forked version)
     #   https://trac.transmissionbt.com/browser/trunk/extras/rpc-spec.txt
 
     PLUGIN_NAMES = ["transmission"]
@@ -65,12 +73,20 @@ class Plugin(BaseClient):
         if transmissionrpc is None:
             raise RuntimeError("Required module transmissionrpc")
 
-        self._client = transmissionrpc.Client(
-            address=url,
-            user=(user or None),
-            password=(passwd or None),
-            timeout=timeout,
-        )
+        if transmissionrpc.project is "original":
+            self._client = transmissionrpc.Client(
+                address=url,
+                user=(user or None),
+                password=(passwd or None),
+                timeout=timeout,
+            )
+        elif transmissionrpc.project is "forked":
+            self._client = transmissionrpc.Client(
+                host=url,
+                username=(user or None),
+                password=(passwd or None),
+                timeout=timeout,
+            )
 
     @classmethod
     def get_options(cls) -> Dict[str, Option]:

--- a/emonoda/plugins/clients/transmission.py
+++ b/emonoda/plugins/clients/transmission.py
@@ -161,6 +161,9 @@ class Plugin(BaseClient):
         flist = [
             (item["name"], item["size"])
             for item in self.__get_files(torrent_hash).values()
+        ] if transmissionrpc.project is "original" else [
+            (item.name, item.size)
+            for item in self.__get_files(torrent_hash)
         ]
         return build_files("", flist)
 


### PR DESCRIPTION
А тем временем оригинальный transmissionrpc заброшен и не обновляется. Однако форк уже появился — вот он: https://github.com/Trim21/transmission-rpc

Разумеется, с некоторыми небольшими несовместимыми изменениями. Кстати, пакет из AUR [уже перешёл](https://aur.archlinux.org/cgit/aur.git/commit/?h=python-transmissionrpc&id=1a8ce14015a3e29449cb5b6c3f9aa9471114482e) на версию из форка, то есть в текущем виде возможность соединяться с Transmission временно утрачена.

Ну а этот PR возвращает утраченное, сохраняя при этом совместимость как с форком, так и с оригинальным проектом. Вроде бы всё работает как ожидается.
