### PR TITLE
qbittorrent2: fix torrent deletion

### DIFF
--- a/emonoda/plugins/clients/qbittorrent2.py
+++ b/emonoda/plugins/clients/qbittorrent2.py
@@ -121,7 +121,7 @@ class Plugin(BaseClient):
         self.__get_torrent_props(torrent_hash)
         self.__post(
             path="torrents/delete",
-            payload={"hashes": torrent_hash},
+            payload={"hashes": torrent_hash, "deleteFiles": False},
         )
 
     @hash_or_torrent


### PR DESCRIPTION
Поправил баг - торренты не удалялись через новое API qBittorrent.