### PR TITLE
Использование внешних плагинов для конфетти

### DIFF
--- a/emonoda/plugins/__init__.py
+++ b/emonoda/plugins/__init__.py
@@ -72,8 +72,13 @@ def get_classes(sub: str) -> Dict[str, Type[BasePlugin]]:
     classes: Dict[str, Type[BasePlugin]] = {}  # noqa: E701
     sub_path = os.path.join(os.path.dirname(__file__), sub)
     for file_name in os.listdir(sub_path):
-        if not file_name.startswith("__") and file_name.endswith(".py"):
-            module_name = file_name[:-3]
+        if not file_name.startswith("__"):
+            if file_name.endswith(".py"):
+                module_name = file_name[:-3]
+            elif os.path.exists(os.path.join(sub_path, file_name, "__init__.py")):
+                module_name = file_name
+            else:
+                continue
             module = importlib.import_module(f"emonoda.plugins.{sub}.{module_name}")
             plugin_class = getattr(module, "Plugin")
             for plugin_name in plugin_class.PLUGIN_NAMES:

--- a/emonoda/plugins/confetti/__init__.py
+++ b/emonoda/plugins/confetti/__init__.py
@@ -57,19 +57,6 @@ STATUSES = {
 
 
 # =====
-def templated(name: str, built_in: bool=True, **kwargs: Any) -> str:
-    if built_in:
-        data = pkgutil.get_data(__name__, os.path.join("templates", name))
-        assert data, (data, name, __name__)
-        text = data.decode()
-    else:
-        with open(name) as template_file:
-            text = template_file.read()
-    template = textwrap.dedent(text).strip()
-    return mako.template.Template(template).render(**kwargs).strip()
-
-
-# =====
 class UpdateResult(NamedTuple):
     torrent: Optional[Torrent]
     tracker: Optional[BaseTracker]
@@ -107,6 +94,21 @@ class BaseConfetti(BasePlugin):
 
     def send_results(self, source: str, results: ResultsType) -> None:
         raise NotImplementedError
+
+    
+    @classmethod
+    def templated(cls, name: str, built_in: bool=True, **kwargs: Any) -> str:
+        if built_in:
+            module_name = cls.__module__
+            data = pkgutil.get_data(module_name, os.path.join("templates", name))
+            assert data, (data, name, module_name)
+            text = data.decode()
+        else:
+            with open(name) as template_file:
+                text = template_file.read()
+        template = textwrap.dedent(text).strip()
+        return mako.template.Template(template).render(**kwargs).strip()
+
 
 
 class WithWeb(BaseConfetti):  # pylint: disable=abstract-method

--- a/emonoda/plugins/confetti/atom.py
+++ b/emonoda/plugins/confetti/atom.py
@@ -39,7 +39,7 @@ from ...optconf.converters import as_path_or_empty
 
 from . import ResultsType
 from . import BaseConfetti
-from . import templated
+# from . import templated
 
 
 # =====
@@ -122,7 +122,7 @@ class Plugin(BaseConfetti):  # pylint: disable=too-many-instance-attributes
             results_set.insert(0, results)
             results_set = results_set[:20]
             with open(self.__path, "w") as atom_file:
-                atom_file.write(templated(
+                atom_file.write(Plugin.templated(
                     name=(self.__template_path if self.__template_path else "atom.{ctype}.{source}.mako").format(
                         ctype=("html" if self.__html else "plain"),
                         source=source,

--- a/emonoda/plugins/confetti/email.py
+++ b/emonoda/plugins/confetti/email.py
@@ -38,7 +38,7 @@ from ...optconf.converters import as_path_or_empty
 
 from . import ResultsType
 from . import WithStatuses
-from . import templated
+# from . import templated
 
 
 # =====
@@ -134,7 +134,7 @@ class Plugin(WithStatuses):  # pylint: disable=too-many-instance-attributes
         subject_placeholders["statuses_sum"] = sum(len(results[status]) for status in self._statuses)
         return self.__make_message(
             subject=self.__subject.format(**subject_placeholders),
-            body=templated(
+            body=Plugin.templated(
                 name=(self.__template_path if self.__template_path else "email.{ctype}.{source}.mako").format(
                     ctype=("html" if self.__html else "plain"),
                     source=source,

--- a/emonoda/plugins/confetti/pushover.py
+++ b/emonoda/plugins/confetti/pushover.py
@@ -32,7 +32,7 @@ from . import STATUSES
 from . import ResultsType
 from . import WithWeb
 from . import WithStatuses
-from . import templated
+# from . import templated
 
 
 # =====
@@ -76,7 +76,7 @@ class Plugin(WithWeb, WithStatuses):
                     "user":    self.__user_key,
                     "html":    "1",
                     "title":   self.__title.format(source=source),
-                    "message": templated(
+                    "message": Plugin.templated(
                         name=(self.__template_path if self.__template_path else "pushover.{source}.mako").format(source=source),
                         built_in=(not self.__template_path),
                         source=source,

--- a/emonoda/plugins/confetti/telegrem.py
+++ b/emonoda/plugins/confetti/telegrem.py
@@ -34,7 +34,7 @@ from . import STATUSES
 from . import ResultsType
 from . import WithWeb
 from . import WithStatuses
-from . import templated
+# from . import templated
 
 
 # =====
@@ -68,7 +68,7 @@ class Plugin(WithWeb, WithStatuses):
 
     def send_results(self, source: str, results: ResultsType) -> None:
         messages = [
-            templated(
+            Plugin.templated(
                 name=(self.__template_path if self.__template_path else "telegram.{source}.mako").format(source=source),
                 built_in=(not self.__template_path),
                 source=source,


### PR DESCRIPTION
Начиная с [PEP-420](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/#native-namespace-packages) мы можем реализовывать внешние плагины, встраивая их в структуру папок emonoda:

```
emonoda-plugin-confetti-hass
├── README.md
├── requirements.txt
├── setup.py
└── src
    └── emonoda
        └── plugins
            └── confetti
                └── hass
                    ├── __init__.py
                    └── templates
                        └── hass.emupdate.mako
emonoda-plugin-confetti-matrix
├── README.md
├── requirements.txt
├── setup.py
└── src
    └── emonoda
        └── plugins
            └── confetti
                └── matrix
                    ├── __init__.py
                    └── templates
                        └── matrix.emupdate.mako
```

Это могут быть любые внешние провайдеры, которые нет необходимости встраивать напрямую в emonoda.

Данный патч позволяет загружать плагины не только из файлов, но и из пакетов, что необходимо для работы механизма из статьи приведённой выше.

Также он меняет роль функции `templated` на `classmethod`, чтобы задействовать возможность поиска шаблонов, которые будут встроены во внешний плагин (см. структуру каталогов выше).